### PR TITLE
Fix NameError 'exit' not defined

### DIFF
--- a/library/cap1xxx.py
+++ b/library/cap1xxx.py
@@ -8,7 +8,10 @@ CAP1188 - 8 Inputs, 8 LEDs
 try:
     from smbus import SMBus
 except ImportError:
-    exit("This library requires python-smbus\nInstall with: sudo apt-get install python-smbus")
+    raise ImportError(
+        "This library requires python-smbus. Install"
+        "with: sudo apt-get install python-smbus or"
+        "sudo apt-get install python3-smbus")
 
 import time, signal, atexit, sys, threading
 import RPi.GPIO as GPIO


### PR DESCRIPTION
When python-smbus or python3-smbus is not installed, the library attempts to exit with a useful error message. Unfortunately `exit` isn't defined and thus the user just winds up with an even more confusing: NameError: name 'exit' is not defined.
