### PR TITLE
isAlive was removed in Python 3.9

### DIFF
--- a/library/cap1xxx.py
+++ b/library/cap1xxx.py
@@ -206,12 +206,12 @@ class StoppableThread(threading.Thread):
         self.daemon = True         
 
     def start(self):
-        if self.isAlive() == False:
+        if not self.is_alive():
             self.stop_event.clear()
             threading.Thread.start(self)
 
     def stop(self):
-        if self.isAlive() == True:
+        if self.is_alive():
             # set event to signal thread to terminate
             self.stop_event.set()
             # block calling thread until thread really has terminated


### PR DESCRIPTION
It was deprecated since Python 3.7. While at this, use more idiomatic handling of bools.