### PR TITLE
Fix thread.isAlive for py3.9 #19

### DIFF
--- a/library/cap1xxx.py
+++ b/library/cap1xxx.py
@@ -205,13 +205,20 @@ class StoppableThread(threading.Thread):
         self.stop_event = threading.Event()
         self.daemon = True         
 
+    def alive(self):
+        try:
+            return self.isAlive()
+        except AttributeError:
+            # Python >= 3.9
+            return self.is_alive()
+
     def start(self):
-        if self.isAlive() == False:
+        if self.alive() == False:
             self.stop_event.clear()
             threading.Thread.start(self)
 
     def stop(self):
-        if self.isAlive() == True:
+        if self.alive() == True:
             # set event to signal thread to terminate
             self.stop_event.set()
             # block calling thread until thread really has terminated


### PR DESCRIPTION
Thread.isAlive is now Thread.is_alive, add a shim to smooth over the change.